### PR TITLE
feat: enable SO_REUSEPORT

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -428,6 +428,8 @@ impl Device {
         // Then open new sockets and bind to the port
         let udp_sock4 = socket2::Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
         udp_sock4.set_reuse_address(true)?;
+        // SO_REUSEPORT is not really needed here, as long as the wildcard address is used in the bind
+        udp_sock4.set_reuse_port(true)?;
         udp_sock4.bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).into())?;
         udp_sock4.set_nonblocking(true)?;
 
@@ -438,6 +440,8 @@ impl Device {
 
         let udp_sock6 = socket2::Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
         udp_sock6.set_reuse_address(true)?;
+        // SO_REUSEPORT is not really needed here, as long as the wildcard address is used in the bind
+        udp_sock6.set_reuse_port(true)?;
         udp_sock6.bind(&SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0).into())?;
         udp_sock6.set_nonblocking(true)?;
 

--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -119,6 +119,8 @@ impl Peer {
         let udp_conn =
             socket2::Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::UDP))?;
         udp_conn.set_reuse_address(true)?;
+        // SO_REUSEPORT is not really needed here, as long as the wildcard address is used in the bind
+        udp_conn.set_reuse_port(true)?;
         let bind_addr = if addr.is_ipv4() {
             SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).into()
         } else {


### PR DESCRIPTION
tbh, I don't think SO_REUSEPORT has any effect in this case, as the binds all use wildcard addresses and already have SO_REUSEADDR